### PR TITLE
Allow override of credentials file and use passphrase

### DIFF
--- a/src/main/groovy/nu/studer/gradle/credentials/CredentialsPlugin.java
+++ b/src/main/groovy/nu/studer/gradle/credentials/CredentialsPlugin.java
@@ -48,7 +48,7 @@ public class CredentialsPlugin implements Plugin<Project> {
         String credentialsFileName = deriveFileNameFromPassphrase(passphrase);
 
         // create credentials encryptor for the given passphrase
-        CredentialsEncryptor credentialsEncryptor = CredentialsEncryptor.withPassphrase(CredentialsPlugin.DEFAULT_PASSPHRASE.toCharArray());
+        CredentialsEncryptor credentialsEncryptor = CredentialsEncryptor.withPassphrase(passphrase.toCharArray());
 
         // create a credentials persistence manager that operates on the credentials file
         File gradleUserHomeDir = project.getGradle().getGradleUserHomeDir();

--- a/src/main/groovy/nu/studer/gradle/credentials/CredentialsPlugin.java
+++ b/src/main/groovy/nu/studer/gradle/credentials/CredentialsPlugin.java
@@ -53,6 +53,11 @@ public class CredentialsPlugin implements Plugin<Project> {
         // create a credentials persistence manager that operates on the credentials file
         File gradleUserHomeDir = project.getGradle().getGradleUserHomeDir();
         File credentialsFile = new File(gradleUserHomeDir, credentialsFileName);
+
+        if(project.hasProperty("credentialsFile")) {
+            credentialsFile = project.file(project.getProperties().get("credentialsFile"));
+        }
+
         CredentialsPersistenceManager credentialsPersistenceManager = new CredentialsPersistenceManager(credentialsFile);
 
         // add a new 'credentials' property and transiently store the persisted credentials for access in build scripts


### PR DESCRIPTION
The plugin currently assumes that the credentials file is stored in the gradle user directory instead of the project directory. This allows overriding to use a file within the project.

Also, the plugin was always using the default passphrase for encryption.