### PR TITLE
improve support for Java 9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ buildScan {
 
 dependencies {
   compile "nu.studer:java-ordered-properties:$orderedPropertiesVersion"
+  compile "commons-codec:commons-codec:$commonsCodecVersion"
   testCompile "junit:junit:$junitVersion"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,5 @@ buildScanPluginVersion=1.6
 # compile/runtime dependency versions
 orderedPropertiesVersion = 1.0.1
 junitVersion=4.12
+commonsCodecVersion=1.4
 

--- a/src/main/groovy/nu/studer/gradle/util/Base64.java
+++ b/src/main/groovy/nu/studer/gradle/util/Base64.java
@@ -1,7 +1,5 @@
 package nu.studer.gradle.util;
 
-import javax.xml.bind.DatatypeConverter;
-
 /**
  * Utilities related to Base64 encoding.
  */
@@ -17,7 +15,7 @@ public final class Base64 {
      * @return the resulting Base64 string
      */
     public static String encodeBase64(byte[] bytes) {
-        return DatatypeConverter.printBase64Binary(bytes);
+        return org.apache.commons.codec.binary.Base64.encodeBase64String(bytes);
     }
 
     /**
@@ -27,7 +25,7 @@ public final class Base64 {
      * @return the resulting bytes
      */
     public static byte[] decodeBase64(String string) {
-        return DatatypeConverter.parseBase64Binary(string);
+        return org.apache.commons.codec.binary.Base64.decodeBase64(string);
     }
 
 }

--- a/src/main/groovy/nu/studer/gradle/util/MD5.java
+++ b/src/main/groovy/nu/studer/gradle/util/MD5.java
@@ -1,7 +1,8 @@
 package nu.studer.gradle.util;
 
-import javax.xml.bind.DatatypeConverter;
 import java.security.MessageDigest;
+
+import org.apache.commons.codec.binary.Hex;
 
 /**
  * Utilities related to MD5 hashing.
@@ -21,7 +22,7 @@ public final class MD5 {
         try {
             MessageDigest digest = MessageDigest.getInstance("MD5");
             byte[] hashedBytes = digest.digest(string.getBytes("UTF-8"));
-            return DatatypeConverter.printHexBinary(hashedBytes);
+            return Hex.encodeHexString(hashedBytes).toUpperCase();
         } catch (Exception e) {
             throw new RuntimeException("Cannot generate MD5 hash for string '" + string + "': " + e.getMessage(), e);
         }

--- a/src/test/groovy/nu/studer/gradle/util/MD5Test.java
+++ b/src/test/groovy/nu/studer/gradle/util/MD5Test.java
@@ -2,7 +2,7 @@ package nu.studer.gradle.util;
 
 import org.junit.Test;
 
-import javax.xml.bind.DatatypeConverter;
+import org.apache.commons.codec.binary.Hex;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -24,7 +24,7 @@ public class MD5Test {
     @Test
     public void convertByteArrayToHexString() throws Exception {
         byte[] bytes = new byte[]{-128, -1, 0, 9, 10, 11, 17, 127};
-        String hex = DatatypeConverter.printHexBinary(bytes);
+        String hex = Hex.encodeHexString(bytes).toUpperCase();
         assertEquals("80FF00090A0B117F", hex);
     }
 


### PR DESCRIPTION
improve support for Java 9 by changing the dependency on java.xml.bind to instead be on org.apache.commons.codec. java.xml.bind is not on the default classpath in Java 9