### PR TITLE
Make the plugin applicable to Settings instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,18 @@ a convenient way to avoid having to store credentials in plain text.
 
 ## Apply credentials plugin
 
-Apply the `nu.studer.credentials` plugin to your Gradle plugin project.
+Apply the `nu.studer.credentials` either to your project in the `build.gradle` file:
 
-### Gradle 1.x and 2.0
+```groovy
+plugins {
+  id 'nu.studer.credentials' version '1.0.7'
+}
+```
+
+Please refer to the [Gradle DSL PluginDependenciesSpec](http://www.gradle.org/docs/current/dsl/org.gradle.plugin.use.PluginDependenciesSpec.html) to
+understand the behavior and limitations when using the new syntax to declare plugin dependencies.
+
+...or to the project's settings in the `settings.gradle` file:
 
 ```groovy
 buildscript {
@@ -65,17 +74,6 @@ buildscript {
 
 apply plugin: 'nu.studer.credentials'
 ```
-
-### Gradle 2.1 and higher
-
-```groovy
-plugins {
-  id 'nu.studer.credentials' version '1.0.7'
-}
-```
-
-Please refer to the [Gradle DSL PluginDependenciesSpec](http://www.gradle.org/docs/current/dsl/org.gradle.plugin.use.PluginDependenciesSpec.html) to
-understand the behavior and limitations when using the new syntax to declare plugin dependencies.
 
 ## Invoke credentials tasks
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ credentials using password-based encryption (PBE).
 
 The credentials plugin is hosted at [Bintray's JCenter](https://bintray.com/etienne/gradle-plugins/gradle-credentials-plugin).
 
+The plugin is not compatible with Gradle version older than 4.6.
+
 # Goals
 
 One typical use case of the 'gradle.properties' file in the Gradle user home directory is

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,22 @@ def testAll = tasks.create('testAll') {
   group = 'Verification'
 }
 
+task createClasspathManifest {
+  def outputDir = file("$buildDir/$name")
+
+  inputs.files sourceSets.main.runtimeClasspath
+  outputs.dir outputDir
+
+  doLast {
+    outputDir.mkdirs()
+    file("$outputDir/plugin-classpath.txt").text = sourceSets.main.runtimeClasspath.join("\n")
+  }
+}
+
+dependencies {
+  testRuntime files(createClasspathManifest)
+}
+
 List<String> testedGradleVersions = []
 testedGradleVersions << "5.3.1"
 testedGradleVersions << "5.1"

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'com.gradle.build-scan' version '1.16'
+  id 'com.gradle.build-scan' version '2.2.1'
   id 'nu.studer.plugindev' version '1.0.12'
   id 'nu.studer.credentials' version '1.0.7'
   id 'groovy'
@@ -9,8 +9,8 @@ group = 'nu.studer'
 version = '1.0.8-DEV'
 
 buildScan {
-  licenseAgreementUrl 'https://gradle.com/terms-of-service'
-  licenseAgree 'yes'
+  termsOfServiceUrl 'https://gradle.com/terms-of-service'
+  termsOfServiceAgree 'yes'
 }
 
 dependencies {
@@ -52,11 +52,11 @@ def testAll = tasks.create('testAll') {
 }
 
 List<String> testedGradleVersions = []
+testedGradleVersions << "5.3.1"
 testedGradleVersions << "5.1"
 testedGradleVersions << "5.0"
 testedGradleVersions << "4.10.3"
-testedGradleVersions << "4.0.2"
-testedGradleVersions << "3.5.1"
+testedGradleVersions << "4.6"
 
 testedGradleVersions.each { version ->
   project.tasks.create("test_" + version.replaceAll("[^a-zA-Z0-9]", "_"), Test).with {

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ dependencies {
 }
 
 List<String> testedGradleVersions = []
-testedGradleVersions << "5.3.1"
+testedGradleVersions << "5.5"
 testedGradleVersions << "5.1"
 testedGradleVersions << "5.0"
 testedGradleVersions << "4.10.3"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.3.1-all.zip

--- a/src/main/groovy/nu/studer/gradle/credentials/AddCredentialsTask.java
+++ b/src/main/groovy/nu/studer/gradle/credentials/AddCredentialsTask.java
@@ -4,10 +4,10 @@ import nu.studer.gradle.credentials.domain.CredentialsEncryptor;
 import nu.studer.gradle.credentials.domain.CredentialsPersistenceManager;
 import nu.studer.java.util.OrderedProperties;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.internal.tasks.options.Option;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,13 +35,11 @@ public class AddCredentialsTask extends DefaultTask {
     }
 
     @Option(option = "key", description = "The credentials key.")
-    @org.gradle.api.tasks.options.Option(option = "key", description = "The credentials key.")
     public void setKey(String key) {
         this.key = key;
     }
 
     @Option(option = "value", description = "The credentials value.")
-    @org.gradle.api.tasks.options.Option(option = "value", description = "The credentials value.")
     public void setValue(String value) {
         this.value = value;
     }

--- a/src/main/groovy/nu/studer/gradle/credentials/CredentialsPlugin.java
+++ b/src/main/groovy/nu/studer/gradle/credentials/CredentialsPlugin.java
@@ -5,8 +5,14 @@ import nu.studer.gradle.credentials.domain.CredentialsEncryptor;
 import nu.studer.gradle.credentials.domain.CredentialsPersistenceManager;
 import nu.studer.gradle.util.AlwaysFalseSpec;
 import nu.studer.gradle.util.MD5;
+import nu.studer.java.util.OrderedProperties;
+import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.initialization.Settings;
+import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.api.plugins.ExtraPropertiesExtension;
+import org.gradle.api.tasks.TaskContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,7 +29,7 @@ import java.io.File;
  * <p>
  * The plugin adds a task to add credentials and a task to remove credentials.
  */
-public class CredentialsPlugin implements Plugin<Project> {
+public class CredentialsPlugin implements Plugin<ExtensionAware> {
 
     public static final String DEFAULT_PASSPHRASE_CREDENTIALS_FILE = "gradle.encrypted.properties";
     public static final String DEFAULT_PASSPHRASE = ">>Default passphrase to encrypt passwords!<<";
@@ -41,60 +47,132 @@ public class CredentialsPlugin implements Plugin<Project> {
     private static final Logger LOGGER = LoggerFactory.getLogger(CredentialsPlugin.class);
 
     @Override
-    public void apply(Project project) {
-        // get the passphrase from the project properties, otherwise use the default passphrase
-        String passphrase = getProjectProperty(CREDENTIALS_PASSPHRASE_PROPERTY, DEFAULT_PASSPHRASE, project);
+    public void apply(ExtensionAware target) {
+        Applier applier;
 
-        // derive the name of the credentials file from the passphrase
-        String credentialsFileName = deriveFileNameFromPassphrase(passphrase);
-
-        // create credentials encryptor for the given passphrase
-        CredentialsEncryptor credentialsEncryptor = CredentialsEncryptor.withPassphrase(passphrase.toCharArray());
-
-        // create a credentials persistence manager that operates on the credentials file, possibly located in a user-configured folder
-        String customCredentialsLocation = getProjectProperty(CREDENTIALS_LOCATION_PROPERTY, null, project);
-        File credentialsLocationDir = customCredentialsLocation != null ? project.file(customCredentialsLocation) : project.getGradle().getGradleUserHomeDir();
-        File credentialsFile = new File(credentialsLocationDir, credentialsFileName);
-        CredentialsPersistenceManager credentialsPersistenceManager = new CredentialsPersistenceManager(credentialsFile);
-
-        // add a new 'credentials' property and transiently store the persisted credentials for access in build scripts
-        CredentialsContainer credentialsContainer = new CredentialsContainer(credentialsEncryptor, credentialsPersistenceManager.readCredentials());
-        project.getExtensions().getExtraProperties().set(CREDENTIALS_CONTAINER_PROPERTY, credentialsContainer);
-        LOGGER.debug("Registered property '" + CREDENTIALS_CONTAINER_PROPERTY + "'");
-
-        // add a task instance that stores new credentials through the credentials persistence manager
-        AddCredentialsTask addCredentials = project.getTasks().create(ADD_CREDENTIALS_TASK_NAME, AddCredentialsTask.class);
-        addCredentials.setDescription("Adds the credentials specified through the project properties 'credentialsKey' and 'credentialsValue'.");
-        addCredentials.setGroup("Credentials");
-        addCredentials.setCredentialsEncryptor(credentialsEncryptor);
-        addCredentials.setCredentialsPersistenceManager(credentialsPersistenceManager);
-        addCredentials.getOutputs().upToDateWhen(AlwaysFalseSpec.INSTANCE);
-        LOGGER.debug(String.format("Registered task '%s'", addCredentials.getName()));
-
-        // add a task instance that removes some credentials through the credentials persistence manager
-        RemoveCredentialsTask removeCredentials = project.getTasks().create(REMOVE_CREDENTIALS_TASK_NAME, RemoveCredentialsTask.class);
-        removeCredentials.setDescription("Removes the credentials specified through the project property 'credentialsKey'.");
-        removeCredentials.setGroup("Credentials");
-        removeCredentials.setCredentialsPersistenceManager(credentialsPersistenceManager);
-        removeCredentials.getOutputs().upToDateWhen(AlwaysFalseSpec.INSTANCE);
-        LOGGER.debug(String.format("Registered task '%s'", removeCredentials.getName()));
-    }
-
-    private String deriveFileNameFromPassphrase(String passphrase) {
-        // derive the name of the file that contains the credentials from the given passphrase
-        String credentialsFileName;
-        if (passphrase.equals(DEFAULT_PASSPHRASE)) {
-            credentialsFileName = DEFAULT_PASSPHRASE_CREDENTIALS_FILE;
-            LOGGER.debug("No explicit passphrase provided. Using default credentials file name: " + credentialsFileName);
+        if (target instanceof Project) {
+            applier = new ProjectApplier((Project) target);
         } else {
-            credentialsFileName = "gradle." + MD5.generateMD5Hash(passphrase) + ".encrypted.properties";
-            LOGGER.debug("Custom passphrase provided. Using credentials file name: " + credentialsFileName);
+            if (target instanceof Settings) {
+                applier = new SettingsApplier((Settings) target);
+            } else {
+                throw new GradleException("The specified target has an unsupported type: " +
+                        target.getClass().getName());
+            }
         }
-        return credentialsFileName;
+
+        applier.apply();
     }
 
-    private String getProjectProperty(String key, String defaultValue, Project project) {
-        return project.hasProperty(key) ? (String) project.property(key) : defaultValue;
+    private static abstract class Applier<T extends ExtensionAware> {
+        protected final T target;
+
+        protected final CredentialsEncryptor credentialsEncryptor;
+        protected final CredentialsPersistenceManager credentialsPersistenceManager;
+
+        protected Applier(T target) {
+            this.target = target;
+            // get the passphrase from the project properties, otherwise use the default passphrase
+            String passphrase = getProperty(CREDENTIALS_PASSPHRASE_PROPERTY, DEFAULT_PASSPHRASE);
+
+            // derive the name of the credentials file from the passphrase
+            String credentialsFileName = deriveFileNameFromPassphrase(passphrase);
+
+            // create credentials encryptor for the given passphrase
+            this.credentialsEncryptor = CredentialsEncryptor.withPassphrase(passphrase.toCharArray());
+
+            // create a credentials persistence manager that operates on the credentials file, possibly located in a
+            // user-configured folder
+            String customCredentialsLocation = getProperty(CREDENTIALS_LOCATION_PROPERTY, null);
+            File credentialsLocationDir = this.getCredentialsDirectory(customCredentialsLocation);
+            File credentialsFile = new File(credentialsLocationDir, credentialsFileName);
+            this.credentialsPersistenceManager = new CredentialsPersistenceManager(credentialsFile);
+        }
+
+        void apply() {
+            OrderedProperties credentials = this.credentialsPersistenceManager.readCredentials();
+            // add a new 'credentials' property and transiently store the persisted credentials for access in build scripts
+            CredentialsContainer credentialsContainer =
+                    new CredentialsContainer(this.credentialsEncryptor, credentials);
+            this.target.getExtensions().getExtraProperties().set(CREDENTIALS_CONTAINER_PROPERTY, credentialsContainer);
+            LOGGER.debug("Registered property '" + CREDENTIALS_CONTAINER_PROPERTY + "'");
+        }
+
+        private String getProperty(String key, String defaultValue) {
+            ExtraPropertiesExtension properties = this.target.getExtensions().getExtraProperties();
+
+            return properties.has(key) ? (String) properties.get(key) : defaultValue;
+        }
+
+        protected abstract File getCredentialsDirectory(String customCredentialsLocation);
+
+        private String deriveFileNameFromPassphrase(String passphrase) {
+            // derive the name of the file that contains the credentials from the given passphrase
+            String credentialsFileName;
+            if (passphrase.equals(DEFAULT_PASSPHRASE)) {
+                credentialsFileName = DEFAULT_PASSPHRASE_CREDENTIALS_FILE;
+                LOGGER.debug(
+                        "No explicit passphrase provided. Using default credentials file name: " + credentialsFileName);
+            } else {
+                credentialsFileName = "gradle." + MD5.generateMD5Hash(passphrase) + ".encrypted.properties";
+                LOGGER.debug("Custom passphrase provided. Using credentials file name: " + credentialsFileName);
+            }
+            return credentialsFileName;
+        }
     }
 
+    private static final class ProjectApplier extends Applier<Project> {
+        protected ProjectApplier(Project target) {
+            super(target);
+        }
+
+        @Override
+        void apply() {
+            super.apply();
+
+            TaskContainer taskContainer = this.target.getTasks();
+
+            // add a task instance that stores new credentials through the credentials persistence manager
+            AddCredentialsTask addCredentials =
+                    taskContainer.create(ADD_CREDENTIALS_TASK_NAME, AddCredentialsTask.class);
+            addCredentials.setDescription("Adds the credentials specified through the project properties "
+                    + "'credentialsKey' and 'credentialsValue'.");
+            addCredentials.setGroup("Credentials");
+            addCredentials.setCredentialsEncryptor(this.credentialsEncryptor);
+            addCredentials.setCredentialsPersistenceManager(this.credentialsPersistenceManager);
+            addCredentials.getOutputs().upToDateWhen(AlwaysFalseSpec.INSTANCE);
+            LOGGER.debug(String.format("Registered task '%s'", addCredentials.getName()));
+
+            // add a task instance that removes some credentials through the credentials persistence manager
+            RemoveCredentialsTask removeCredentials =
+                    taskContainer.create(REMOVE_CREDENTIALS_TASK_NAME, RemoveCredentialsTask.class);
+            removeCredentials
+                    .setDescription("Removes the credentials specified through the project property 'credentialsKey'.");
+            removeCredentials.setGroup("Credentials");
+            removeCredentials.setCredentialsPersistenceManager(this.credentialsPersistenceManager);
+            removeCredentials.getOutputs().upToDateWhen(AlwaysFalseSpec.INSTANCE);
+            LOGGER.debug(String.format("Registered task '%s'", removeCredentials.getName()));
+        }
+
+        @Override
+        protected File getCredentialsDirectory(String customCredentialsLocation) {
+            return customCredentialsLocation == null ?
+                    this.target.getGradle().getGradleUserHomeDir() : this.target.file(customCredentialsLocation);
+        }
+    }
+
+    private static final class SettingsApplier extends Applier<Settings> {
+        protected SettingsApplier(Settings target) {
+            super(target);
+        }
+
+        @Override
+        protected File getCredentialsDirectory(String customCredentialsLocation) {
+            if (customCredentialsLocation == null) {
+                return this.target.getGradle().getGradleUserHomeDir();
+            } else {
+                return this.target.getSettingsDir().toPath().resolve(customCredentialsLocation).toFile();
+            }
+        }
+    }
 }

--- a/src/main/groovy/nu/studer/gradle/credentials/RemoveCredentialsTask.java
+++ b/src/main/groovy/nu/studer/gradle/credentials/RemoveCredentialsTask.java
@@ -3,9 +3,9 @@ package nu.studer.gradle.credentials;
 import nu.studer.gradle.credentials.domain.CredentialsPersistenceManager;
 import nu.studer.java.util.OrderedProperties;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.internal.tasks.options.Option;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,7 +26,6 @@ public class RemoveCredentialsTask extends DefaultTask {
     }
 
     @Option(option = "key", description = "The credentials key.")
-    @org.gradle.api.tasks.options.Option(option = "key", description = "The credentials key.")
     public void setKey(String key) {
         this.key = key;
     }


### PR DESCRIPTION
The goal of this PR is to make the plugin applicable to Settings instances. The use case that gave me incentive to make this PR includes usage of credentials for custom repositories inside `pluginManagement` block of `settings.gradle`.

As the `Settings` class became `ExtensionAware` only in Gradle 5.0, I was forced to use Gradle 5 here which broke compatibility of the plugin with Gradle pre-4.6 as `org.gradle.api.internal.tasks.options.Option` was removed in Gradle 5 while `org.gradle.api.tasks.options.Option` was introduced only in Gradle 4.6. I think I can implement a workaround to restore compatibility with older versions if needed.