### PR TITLE
Bump com.gradle.plugin-publish from 0.21.0 to 1.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ import static java.lang.Integer.parseInt
 
 plugins {
     id 'nu.studer.plugindev' version '4.1'
-    id 'com.gradle.plugin-publish' version '0.21.0'
+    id 'com.gradle.plugin-publish' version '1.0.0'
     id 'org.nosphere.gradle.github.actions' version '1.3.2'
     id 'groovy'
 }
@@ -57,6 +57,8 @@ gradlePlugin {
     plugins {
         pluginDevPlugin {
             id = 'nu.studer.credentials'
+            displayName = 'gradle-credentials-plugin'
+            description = 'Gradle plugin to store and access encrypted credentials for use in Gradle builds.'
             implementationClass = 'nu.studer.gradle.credentials.CredentialsPlugin'
         }
     }
@@ -65,17 +67,5 @@ gradlePlugin {
 pluginBundle {
     website = 'https://github.com/etiennestuder/gradle-credentials-plugin'
     vcsUrl = 'https://github.com/etiennestuder/gradle-credentials-plugin'
-    description = 'Gradle plugin to store and access encrypted credentials for use in Gradle builds.'
     tags = ['credentials']
-
-    plugins {
-        pluginDevPlugin {
-            displayName = 'gradle-credentials-plugin'
-        }
-    }
-
-    mavenCoordinates {
-        groupId = 'nu.studer'
-        artifactId = 'gradle-credentials-plugin'
-    }
 }


### PR DESCRIPTION
Dependabot was unable to perform an automated update of `com.gradle.plugin-publish` from 0.21.0 to 1.0.0.

This PR updates the plugin and migrates to the new API.