### PR TITLE
Bump Gradle Wrapper from 8.1 to 8.1.1 in /example/settings_application

### DIFF
--- a/example/settings_application/gradle/wrapper/gradle-wrapper.properties
+++ b/example/settings_application/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=a62c5f99585dd9e1f95dab7b9415a0e698fa9dd1e6c38537faa81ac078f4d23e
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
+distributionSha256Sum=e111cb9948407e26351227dabce49822fb88c37ee72f1d1582a69c68af2e702f
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Bumps Gradle Wrapper from 8.1 to 8.1.1.

Release notes of Gradle 8.1.1 can be found here:
https://docs.gradle.org/8.1.1/release-notes.html